### PR TITLE
Simplify the creation of ClientRecord in close

### DIFF
--- a/src/tls_connection.rs
+++ b/src/tls_connection.rs
@@ -177,17 +177,9 @@ where
 
     /// Close a connection instance, returning the ownership of the config, random generator and the async I/O provider.
     pub async fn close(self) -> Result<(TlsContext<'a, CipherSuite, RNG>, Socket), TlsError> {
-        let record = if self.opened {
-            ClientRecord::Alert(
-                Alert::new(AlertLevel::Warning, AlertDescription::CloseNotify),
-                true,
-            )
-        } else {
-            ClientRecord::Alert(
-                Alert::new(AlertLevel::Warning, AlertDescription::CloseNotify),
-                false,
-            )
-        };
+        let record = ClientRecord::Alert(
+            Alert::new(AlertLevel::Warning, AlertDescription::CloseNotify),
+            self.opened);
 
         let mut key_schedule = self.key_schedule;
         let mut delegate = self.delegate;


### PR DESCRIPTION
This commit removes the if/let expression in async TLsConnection's
`close` method and instead uses the the bool `opened` as the value of the
encrypted argument passed to ClientRecord::Alert.