### PR TITLE
Use warn instead of error for tests

### DIFF
--- a/tests/tlsserver.rs
+++ b/tests/tlsserver.rs
@@ -185,7 +185,7 @@ impl Connection {
                 return;
             }
 
-            log::error!("read error {:?}", err);
+            log::warn!("read error {:?}", err);
             self.closing = true;
             return;
         }
@@ -199,7 +199,7 @@ impl Connection {
         // Process newly-received TLS messages.
         let processed = self.tls_session.process_new_packets();
         if processed.is_err() {
-            log::error!("cannot process packet: {:?}", processed);
+            log::warn!("cannot process packet: {:?}", processed);
 
             // last gasp write to send any alerts
             self.do_tls_write_and_handle_error();
@@ -215,7 +215,7 @@ impl Connection {
 
         let rc = self.tls_session.read_to_end(&mut buf);
         if rc.is_err() {
-            log::error!("plaintext read failed: {:?}", rc);
+            log::warn!("plaintext read failed: {:?}", rc);
             self.closing = true;
             return;
         }
@@ -237,7 +237,7 @@ impl Connection {
         let rc = try_read(back.read(&mut buf));
 
         if rc.is_err() {
-            log::error!("backend read failed: {:?}", rc);
+            log::warn!("backend read failed: {:?}", rc);
             self.closing = true;
             return;
         }
@@ -274,7 +274,7 @@ impl Connection {
     fn do_tls_write_and_handle_error(&mut self) {
         let rc = self.tls_write();
         if rc.is_err() {
-            log::error!("write failed {:?}", rc);
+            log::warn!("write failed {:?}", rc);
             self.closing = true;
             return;
         }


### PR DESCRIPTION
This commit suggests using warn level messages instead of error to avoid
what looks like errors when running tests:

```console
test test_blocking_ping ... ok
[2021-11-04T09:20:48Z ERROR client_test::tlsserver] plaintext read failed: Err(Custom { kind: ConnectionAborted, error: "CloseNotify alert received" })
test test_ping ... ok
```
With this change these messages will not be show for a normal test run
but can be seen if run with `env RUST_LOG=warn`.