### PR TITLE
key_schedule: prevent rare case of nonce reuse

### DIFF
--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -67,11 +67,11 @@ where
     }
 
     pub(crate) fn increment_read_counter(&mut self) {
-        self.read_counter += 1;
+        self.read_counter = self.read_counter.checked_add(1).unwrap()
     }
 
     pub(crate) fn increment_write_counter(&mut self) {
-        self.write_counter += 1;
+        self.write_counter = self.write_counter.checked_add(1).unwrap()
     }
 
     pub(crate) fn reset_write_counter(&mut self) {


### PR DESCRIPTION
Thanks for this crate!

I noticed this in the key schedule - the read and write record sequence numbers will wrap in release builds.

From [RFC 8446 Section 5.3](https://datatracker.ietf.org/doc/html/rfc8446#section-5.3):

> Because the size of sequence numbers is 64-bit, they should not wrap.
> If a TLS implementation would need to wrap a sequence number, it MUST
> either rekey ([Section 4.6.3](https://datatracker.ietf.org/doc/html/rfc8446#section-4.6.3)) or terminate the connection.

This is probably an impossible attack because 2<sup>64</sup> - 1 is a big number, and embedded devices are slow.  Ideally this should terminate the connection or re-key, but a panic is better than nonce reuse, which is [catastrophic for AES-GCM](https://crypto.stackexchange.com/a/68525).